### PR TITLE
Use read pairing information in kneaddata_bowtie2_discordant_pairs

### DIFF
--- a/kneaddata/bowtie2_discordant_pairs.py
+++ b/kneaddata/bowtie2_discordant_pairs.py
@@ -215,16 +215,11 @@ def process_alignments(pair1_sam, pair2_sam, orphan_sam, aligned_pair, unaligned
             query_id_2, mate_2, is_aligned_2, read_2 = read_sam_line(line_2)
             if (mateIds_are_equal=='True'):
                 if not (query_id_1 == query_id_2 and mate_1 == mate_2):
-                    raise ValueError(
-                        "sam files do not match on line {0}: found IDs {1}{2} and {3}{4}"
-                            .format(line_count, query_id_1, mate_1, query_id_2, mate_2)
-                        )
+                    raise ValueError("Queries: "+str(query_id_1)+", "+str(query_id_2)+" mates: "+str(mate_1)+", "+str(mate_2)+". Mates do not match.")
             else:
                 if not (query_id_1 == query_id_2 and mate_1 != mate_2):
-                    raise ValueError(
-                        "sam files do not match on line {0}: found IDs {1}{2} and {3}{4}"
-                            .format(line_count, query_id_1, mate_1, query_id_2, mate_2)
-                        )
+                    raise ValueError("QueryIds: "+str(query_id_1)+","+str(query_id_2)+" mates: "+str(mate_1)+", "+str(mate_2)+". Mates match.")
+                
             aa = is_aligned_1 and is_aligned_2 or (treat_pair_as_aligned_if_either_read_aligned and (is_aligned_1 or is_aligned_2))
 
             x1 = 'both_aligned' if aa else 'only_this_aligned' if is_aligned_1 else 'only_this_unaligned' if is_aligned_2 else 'both_unaligned'

--- a/kneaddata/bowtie2_discordant_pairs.py
+++ b/kneaddata/bowtie2_discordant_pairs.py
@@ -172,18 +172,13 @@ def run_command(command, **kwargs):
             message+="\nError message returned:\n" + e.output
         sys.exit(message)
     
-
 def read_sam_line(line,query_mate_separator):
     data=line.rstrip().split("\t")
     separatorLocation = data[0].find(query_mate_separator)
     query_id = data[0][:separatorLocation]
-    print(query_id)
     mate = data[0][separatorLocation+1]
-    print(mate)
     is_aligned = not (int(data[1]) & 4)
-    print(is_aligned)
     read="\n".join(["@"+data[0], data[9], "+", data[10], ""])
-    print(read)
     return (query_id, mate, is_aligned, read)
 
 def process_alignments(pair1_sam, pair2_sam, orphan_sam, aligned_pair, unaligned_pair, aligned_orphan, unaligned_orphan, mateIds_are_equal, query_mate_separator, treat_pair_as_aligned_if_either_read_aligned):
@@ -224,16 +219,11 @@ def process_alignments(pair1_sam, pair2_sam, orphan_sam, aligned_pair, unaligned
             query_id_2, mate_2, is_aligned_2, read_2 = read_sam_line(line_2,query_mate_separator)
             if (mateIds_are_equal=='True'):
                 if not (query_id_1 == query_id_2 and mate_1 == mate_2):
-                    raise ValueError(
-                        "sam files do not match on line {0}: found IDs {1}{2} and {3}{4}"
-                            .format(line_count, query_id_1, mate_1, query_id_2, mate_2)
-                        )
+                    raise ValueError("QueryIds: "+str(query_id_1)+","+str(query_id_1)+" mates: "+str(mate_1)+","+str(mate_2)+". Mates do not match on line.")
             else:
                 if not (query_id_1 == query_id_2 and mate_1 != mate_2):
-                    raise ValueError(
-                        "QueryIds: "+str(query_id_1)+","+str(query_id_1)+" mates: "+str(mate_1)+","+str(mate_2)+", sam files do not match on line {0}: found IDs {1}{2} and {3}{4}"
-                            .format(line_count, query_id_1, mate_1, query_id_2, mate_2)
-                        )
+                    raise ValueError("QueryIds: "+str(query_id_1)+","+str(query_id_1)+" mates: "+str(mate_1)+","+str(mate_2)+". Mates match.")
+                
             aa = is_aligned_1 and is_aligned_2 or (treat_pair_as_aligned_if_either_read_aligned and (is_aligned_1 or is_aligned_2))
 
             x1 = 'both_aligned' if aa else 'only_this_aligned' if is_aligned_1 else 'only_this_unaligned' if is_aligned_2 else 'both_unaligned'

--- a/kneaddata/knead_data.py
+++ b/kneaddata/knead_data.py
@@ -145,6 +145,11 @@ def parse_arguments(args):
         dest='bmtagger',
         help="run BMTagger instead of Bowtie2 to identify contaminant reads")
     group1.add_argument(
+        "--mateIds_are_equal",
+        choices=('True','False'),
+        dest='mateIds_are_equal',
+        help="Are mates in paired reads equal or different. I.e. 1 and 1 or 1 and 2")
+    group1.add_argument(
         "--bypass-trf",
         action="store_true",
         help="option to bypass the removal of tandem repeats")

--- a/kneaddata/knead_data.py
+++ b/kneaddata/knead_data.py
@@ -150,6 +150,11 @@ def parse_arguments(args):
         dest='mateIds_are_equal',
         help="Are mates in paired reads equal or different. I.e. 1 and 1 or 1 and 2")
     group1.add_argument(
+        "--query_mate_separator",
+        dest='query_mate_separator',
+        help="Seperator between queryid and mate",
+        required=True)
+    group1.add_argument(
         "--bypass-trf",
         action="store_true",
         help="option to bypass the removal of tandem repeats")

--- a/kneaddata/run.py
+++ b/kneaddata/run.py
@@ -51,7 +51,7 @@ def fastqc(fastqc_path, output_dir, input_files, threads, verbose):
 
 
 def align(infile_list, db_prefix_list, output_prefix, remove_temp_output,
-          bowtie2_path, threads, processors, bowtie2_opts, verbose, mateIds_are_equal,
+          bowtie2_path, threads, processors, bowtie2_opts, verbose, mateIds_are_equal, query_mate_separator,
           discordant=None, reorder=None, serial=None, decontaminate_pairs=None):
     """ Runs bowtie2 on a single-end sequence file or a paired-end set of files. 
     For each input file set and database provided, a bowtie2 command is generated and run."""
@@ -86,7 +86,7 @@ def align(infile_list, db_prefix_list, output_prefix, remove_temp_output,
                 current_infile_list=infile_list
             
             # run the pairs allowing for all alignments (including those generating orphans)
-            cmd=["kneaddata_bowtie2_discordant_pairs","--mateIds_are_equal",mateIds_are_equal,"--bowtie2",bowtie2_path,"--threads", str(threads),"-x",fullpath,"--mode",decontaminate_pairs]
+            cmd=["kneaddata_bowtie2_discordant_pairs","--mateIds_are_equal",mateIds_are_equal,"--query_mate_separator",query_mate_separator,"--bowtie2",bowtie2_path,"--threads", str(threads),"-x",fullpath,"--mode",decontaminate_pairs]
 
             if bowtie2_opts:
                 cmd+=["--bowtie2-options","\""+" ".join(bowtie2_opts)+"\""]
@@ -163,7 +163,7 @@ def align(infile_list, db_prefix_list, output_prefix, remove_temp_output,
     # run the bowtie2 commands with the number of processes specified
     utilities.start_processes(commands,processors,verbose)
 
-    # write out total number of contaminated reads found
+     # write out total number of contaminated reads found
     for file in all_contaminated_outputs:
         total_contaminates=utilities.count_reads_in_fastq_file(file, verbose)
         message="Total contaminate sequences in file ( " + file + " ) : " + str(total_contaminates)
@@ -560,7 +560,7 @@ def decontaminate(args, output_prefix, files_to_align):
     if not args.bmtagger and args.discordant and isinstance(files_to_align[0], list) and len(files_to_align[0]) == 2:
         alignment_output_files = align([files_to_align[0][0],files_to_align[0][1]]+utilities.resolve_sublists(files_to_align[1:]), 
             args.reference_db, output_prefix, args.remove_temp_output, args.bowtie2_path, args.threads,
-                                       args.processes, args.bowtie2_options, args.verbose, args.mateIds_are_equal, discordant=args.discordant, 
+                                       args.processes, args.bowtie2_options, args.verbose, args.mateIds_are_equal, args.query_mate_separator, discordant=args.discordant, 
             reorder=args.reorder, serial=args.serial, decontaminate_pairs=args.decontaminate_pairs)
         output_files=alignment_output_files
     else:
@@ -579,7 +579,7 @@ def decontaminate(args, output_prefix, files_to_align):
             else:
                 alignment_output_files = align(files_list, args.reference_db, prefix, 
                                args.remove_temp_output, args.bowtie2_path, args.threads,
-                                               args.processes, args.bowtie2_options, args.verbose, args.mateIds_are_equal, serial=args.serial)
+                                               args.processes, args.bowtie2_options, args.verbose, args.mateIds_are_equal, args.query_mate_separator, serial=args.serial)
              
             output_files.append(alignment_output_files)   
             

--- a/kneaddata/run.py
+++ b/kneaddata/run.py
@@ -51,7 +51,7 @@ def fastqc(fastqc_path, output_dir, input_files, threads, verbose):
 
 
 def align(infile_list, db_prefix_list, output_prefix, remove_temp_output,
-          bowtie2_path, threads, processors, bowtie2_opts, verbose, 
+          bowtie2_path, threads, processors, bowtie2_opts, verbose, mateIds_are_equal,
           discordant=None, reorder=None, serial=None, decontaminate_pairs=None):
     """ Runs bowtie2 on a single-end sequence file or a paired-end set of files. 
     For each input file set and database provided, a bowtie2 command is generated and run."""
@@ -86,8 +86,8 @@ def align(infile_list, db_prefix_list, output_prefix, remove_temp_output,
                 current_infile_list=infile_list
             
             # run the pairs allowing for all alignments (including those generating orphans)
-            cmd=["kneaddata_bowtie2_discordant_pairs","--bowtie2",bowtie2_path,"--threads", str(threads),"-x",fullpath,"--mode",decontaminate_pairs]
-            
+            cmd=["kneaddata_bowtie2_discordant_pairs","--mateIds_are_equal",mateIds_are_equal,"--bowtie2",bowtie2_path,"--threads", str(threads),"-x",fullpath,"--mode",decontaminate_pairs]
+
             if bowtie2_opts:
                 cmd+=["--bowtie2-options","\""+" ".join(bowtie2_opts)+"\""]
             
@@ -560,7 +560,7 @@ def decontaminate(args, output_prefix, files_to_align):
     if not args.bmtagger and args.discordant and isinstance(files_to_align[0], list) and len(files_to_align[0]) == 2:
         alignment_output_files = align([files_to_align[0][0],files_to_align[0][1]]+utilities.resolve_sublists(files_to_align[1:]), 
             args.reference_db, output_prefix, args.remove_temp_output, args.bowtie2_path, args.threads,
-            args.processes, args.bowtie2_options, args.verbose, discordant=args.discordant, 
+                                       args.processes, args.bowtie2_options, args.verbose, args.mateIds_are_equal, discordant=args.discordant, 
             reorder=args.reorder, serial=args.serial, decontaminate_pairs=args.decontaminate_pairs)
         output_files=alignment_output_files
     else:
@@ -579,7 +579,7 @@ def decontaminate(args, output_prefix, files_to_align):
             else:
                 alignment_output_files = align(files_list, args.reference_db, prefix, 
                                args.remove_temp_output, args.bowtie2_path, args.threads,
-                               args.processes, args.bowtie2_options, args.verbose, serial=args.serial)
+                                               args.processes, args.bowtie2_options, args.verbose, args.mateIds_are_equal, serial=args.serial)
              
             output_files.append(alignment_output_files)   
             

--- a/kneaddata/tests/functional_tests.py
+++ b/kneaddata/tests/functional_tests.py
@@ -480,7 +480,7 @@ class TestFunctionalKneadData(unittest.TestCase):
         # run kneaddata test
         command = ["kneaddata","--input",cfg.fastq_file,
                    "--output",tempdir,"--reference-db",cfg.bowtie2_db_folder,
-                   "--store-temp-output","--bypass-trim"]
+                   "--store-temp-output","--bypass-trim", "--bypass-trf"]
         utils.run_kneaddata(command)
         
         # get the basename of the input file
@@ -501,7 +501,7 @@ class TestFunctionalKneadData(unittest.TestCase):
         utils.remove_temp_folder(tempdir)
         
     @skipIfExeNotFound(config.bowtie2_exe)
-    def test_bowtie2_only_paired_end_remove_intermedite_temp_output(self):
+    def test_bowtie2_only_paired_end_remove_intermediate_temp_output(self):
         """
         Test running the default flow of trimmomatic on paired end input with a
         bowtie2 database provided
@@ -513,7 +513,7 @@ class TestFunctionalKneadData(unittest.TestCase):
         
         # run kneaddata test
         command = ["kneaddata","--input",cfg.fastq_file,"--input",cfg.fastq_file,
-                   "--output",tempdir,"--reference-db",cfg.bowtie2_db_folder,"--bypass-trim","--no-discordant"]
+                   "--output",tempdir,"--reference-db",cfg.bowtie2_db_folder,"--bypass-trim","--no-discordant", "--bypass-trf"]
         utils.run_kneaddata(command)
         
         # get the basename of the input file

--- a/kneaddata/utilities.py
+++ b/kneaddata/utilities.py
@@ -348,7 +348,8 @@ def get_first_n_seq_identifiers(file,n):
     first_seq_identifiers=[]
     # Getting first nth seq identifier
     while(count<n):
-        lines=next(all_lines)
+        lines=next(all_lines, None)
+        if lines is None: break
         first_seq_identifiers.append(lines[0])
         count+=1
     return first_seq_identifiers


### PR DESCRIPTION
I had a problem with kneaddata_bowtie2_discordant_pairs taking increasingly more memory based on the input size. I've tracked it down to this script having to re-order the alignment information, for which it was storing IDs in a set.

I have reimplemented the script to avoid this step, by letting it assume the two paired read files are indeed paired, and making bowtie2 runs separately for each mate with --reorder. The output is then more easily interpreted by iterating through the results. 

The changed script no longer works for out of order paired reads. It accommodates one mate of the pair being truncated, and there's enough smartness in the script to check that its assumption is holding true, but not more. I'm not sure how controversial it is - if `kneaddata` ever worked for that case, or if the previous step of Trimmomatic will fix it - and if there is any reason for a bioinformatics tool to support for out of order paired reads, but I want to explicitly note it because it's I guess a drawback.