### PR TITLE
Fix file name in error message 'Unable to write file'

### DIFF
--- a/kneaddata/utilities.py
+++ b/kneaddata/utilities.py
@@ -948,7 +948,7 @@ def fastq_to_fasta(file, new_file):
     try:
         file_out=open(new_file,"w")
     except EnvironmentError:
-        sys.exit("ERROR: Unable to write file: " + file)
+        sys.exit("ERROR: Unable to write file: " + new_file)
 
     sequence=""
     sequence_id=""


### PR DESCRIPTION
Very minor fix, but the bug got me on a wild goose chase when KneadData said it couldn't write to a perfectly writeable file. Turns out it reported the wrong filename.