### PR TITLE
Fix failure in tandem when trim bypassed

### DIFF
--- a/kneaddata/run.py
+++ b/kneaddata/run.py
@@ -501,7 +501,7 @@ def tandem(input_files, output_prefix, match, mismatch, delta, pm, pi, minscore,
         trf_output_files=[]
         for input_fastq in input_fastq_files:
             # create a temp fasta file from the fastq file
-            input_fasta = input_fastq.replace(os.path.splitext(input_fastq)[-1],config.fasta_file_extension)
+            input_fasta = input_fastq + config.fasta_file_extension
             utilities.fastq_to_fasta(input_fastq, input_fasta)
             temp_fasta_files.append(input_fasta)
             


### PR DESCRIPTION
With `--bypass-trim` a failure occurs in `utilities.fastq_to_fasta()`, due to generation of an invalid fasta file name in `run.tandem()`.

The offending statement is:

    input_fastq.replace(os.path.splitext(input_fastq)[-1],config.fasta_file_extension)

When `input_fastq` has no extension (as is the case when `--bypass-trim`), then this evaluates to `input_fastq.replace("",".fasta")`, which results in `.fasta` being inserted at _every position_ in `input_fastq`. This generates file names such as `.fasta/.fastap.fastaa.fastat.fastah.fasta/.fastaf.fastai.fastal.fastae.fasta`.

This patch fixes the issue simply by appending `".fasta"` to `input_fastq`.

Note: PR #21 fixes an independent issue which prevents the offending filename from being shown in the error message. 
