### PR TITLE
Make kneaddata_database use https URLs

### DIFF
--- a/kneaddata/download_db.py
+++ b/kneaddata/download_db.py
@@ -30,17 +30,17 @@ current_downloads={
     # genome/database
     "human_genome" : {
         # database build type
-        "bowtie2" : "http://huttenhower.sph.harvard.edu/kneadData_databases/Homo_sapiens_hg37_and_human_contamination_Bowtie2_v0.1.tar.gz",
-        "bmtagger" : "http://huttenhower.sph.harvard.edu/kneadData_databases/Homo_sapiens_BMTagger_v0.1.tar.gz"
+        "bowtie2" : "https://huttenhower.sph.harvard.edu/kneadData_databases/Homo_sapiens_hg37_and_human_contamination_Bowtie2_v0.1.tar.gz",
+        "bmtagger" : "https://huttenhower.sph.harvard.edu/kneadData_databases/Homo_sapiens_BMTagger_v0.1.tar.gz"
     },
     "human_transcriptome" : {
-        "bowtie2" : "http://huttenhower.sph.harvard.edu/kneadData_databases/Homo_sapiens_hg38_transcriptome_Bowtie2_v0.1.tar.gz"
+        "bowtie2" : "https://huttenhower.sph.harvard.edu/kneadData_databases/Homo_sapiens_hg38_transcriptome_Bowtie2_v0.1.tar.gz"
     },
     "ribosomal_RNA" : {
-        "bowtie2" : "http://huttenhower.sph.harvard.edu/kneadData_databases/SILVA_128_LSUParc_SSUParc_ribosomal_RNA_v0.2.tar.gz"
+        "bowtie2" : "https://huttenhower.sph.harvard.edu/kneadData_databases/SILVA_128_LSUParc_SSUParc_ribosomal_RNA_v0.2.tar.gz"
     },
     "mouse_C57BL" : {
-        "bowtie2" : "http://huttenhower.sph.harvard.edu/kneadData_databases/mouse_C57BL_6NJ_Bowtie2_v0.1.tar.gz"
+        "bowtie2" : "https://huttenhower.sph.harvard.edu/kneadData_databases/mouse_C57BL_6NJ_Bowtie2_v0.1.tar.gz"
     }
 }
 


### PR DESCRIPTION
## Description

This is a small configuration change that updates the download URLs to point to https rather than http for security reasons.

## Related Issue

N.A.

## Screenshots (if appropriate):

N.A.