### PR TITLE
Update setup.py URL references to TRF_exe download

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -243,9 +243,9 @@ def install_trf(final_install_folder, mac_os):
     trf_exe = "trf"
 
     if mac_os:
-        url = "http://tandem.bu.edu/trf/downloads/trf409.macosx"
+        url = "https://github.com/Benson-Genomics-Lab/TRF/releases/download/v4.09.1/trf409.macosx"
     else:
-        url = "http://tandem.bu.edu/trf/downloads/trf409.linux64"
+        url = "https://github.com/Benson-Genomics-Lab/TRF/releases/download/v4.09.1/trf409.linux64"
 
     download_file = os.path.join(final_install_folder, trf_exe)
     download(url, download_file)


### PR DESCRIPTION
We welcome feedback and issue reporting for all bioBakery tools through our [Discourse site](https://forum.biobakery.org/c/pull-request/featurepull-request/). For users that would like to directly contribute to the [tools](https://github.com/biobakery/) we are happy to field PRs to address **bug fixes**. Please note the turn around time on our end might be a bit long to field these but that does not mean we don't value the contribution! We currently **don't** accept PRs to add **new functionality** to tools but we would be happy to receive your feedback on [Discourse](https://forum.biobakery.org/c/pull-request/featurepull-request/).

Also, we will make sure to attribute your contribution in our User’s manual(README.md) and in any associated paper Acknowledgements.


## Description
<!--- Describe your changes in detail -->
Updated URLs to TRF_exe files since referenced web location no longer hosting those files. Files were relocated to GitHub by previous host.

## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Run python setup.py install in an environment that doesn't already have the trf.exe downloaded and included in the directory or path.

## Screenshots (if appropriate):
