### PR TITLE
fix: handle TRF processing for sequences fewer than total processes

### DIFF
--- a/kneaddata/trf_parallel.py
+++ b/kneaddata/trf_parallel.py
@@ -85,6 +85,9 @@ def run_trf(input,trf_path,trf_options,nproc,output,verbose=True):
     datfile_to_write_list=[]
     commands=[]
 
+    total_sequences = sum(1 for line in open(input) if line.startswith('>'))
+    nproc = min(nproc, total_sequences)
+    
     # check for one process and if so just run trf directly
     if nproc == 1:
         commands.append([[trf_path,input]+trf_options.split(" "),"trf",[input],[output],output])


### PR DESCRIPTION
We welcome feedback and issue reporting for all bioBakery tools through our [Discourse site](https://forum.biobakery.org/c/pull-request/featurepull-request/). For users that would like to directly contribute to the [tools](https://github.com/biobakery/) we are happy to field PRs to address **bug fixes**. Please note the turn around time on our end might be a bit long to field these but that does not mean we don't value the contribution! We currently **don't** accept PRs to add **new functionality** to tools but we would be happy to receive your feedback on [Discourse](https://forum.biobakery.org/c/pull-request/featurepull-request/).

Also, we will make sure to attribute your contribution in our User’s manual(README.md) and in any associated paper Acknowledgements.


## Description
Fix TRF parallel processing for scenarios with fewer sequences than configured processes.  

In the current implementation, when input sequences are less than specified processes:  
- Empty temporary files are created  
- TRF execution fails  
- Parallel processing breaks for small datasets  

Modified process allocation logic in `kneaddata/trf_parallel.py` (line 69) to:  
- Dynamically adjust processes based on actual sequence count  
- Prevent creation of unnecessary empty files  
- Ensure TRF can be executed correctly for small input sequences  

Example log showing low sequence count:  

kneaddata.utilities - INFO: READ COUNT: trimmed pair1 : Total reads after trimming ( /path/to/.trimmed.1.fastq ): 25542560.0
kneaddata.utilities - INFO: READ COUNT: trimmed pair2 : Total reads after trimming ( /path/to/.trimmed.2.fastq ): 25542560.0
kneaddata.utilities - INFO: READ COUNT: trimmed orphan1 : Total reads after trimming ( /path/to/.trimmed.single.1.fastq ): 226.0
kneaddata.utilities - INFO: READ COUNT: trimmed orphan2 : Total reads after trimming (/path/to/.trimmed.single.2.fastq ): 7.0

After modification, TRF now successfully processes the 7 sequences, previously impossible with 16 processes (nproc=16).

## Related Issue


## Screenshots (if appropriate):
