### PR TITLE
fix typo download_db.py

### DIFF
--- a/kneaddata/download_db.py
+++ b/kneaddata/download_db.py
@@ -30,7 +30,7 @@ current_downloads={
     # genome/database
     "human_genome" : {
         # database build type
-        "bowtie2" : "https://huttenhower.sph.harvard.edu/kneadData_databases/Homo_sapiens_hg39_T2D_Bowtie2_v0.1.tar.gz",
+        "bowtie2" : "https://huttenhower.sph.harvard.edu/kneadData_databases/Homo_sapiens_hg39_T2T_Bowtie2_v0.1.tar.gz",
         "bmtagger" : "http://huttenhower.sph.harvard.edu/kneadData_databases/Homo_sapiens_BMTagger_v0.1.tar.gz"
     },
     "human_transcriptome" : {


### PR DESCRIPTION
I fixed a typo in the download_db.py script which prevented the download of the human bowtie2 db. 

## Description
When trying to download the homo sapiens db I got a critical error: 
`CRITICAL ERROR: Unable to download and extract from URL: https://huttenhower.sph.harvard.edu/kneadData_databases/Homo_sapiens_hg39_T2D_Bowtie2_v0.1.tar.gz` 

Comparing files at the server, and files linked in the readme I realised that there must be a typo as the correct file is `https://huttenhower.sph.harvard.edu/kneadData_databases/Homo_sapiens_hg39_T2T_Bowtie2_v0.1.tar.gz`. 