### PR TITLE
Fix --bypass-trim failure

### DIFF
--- a/history.md
+++ b/history.md
@@ -4,6 +4,7 @@
 * Added German Shephard Dog Reference DB
 * Enabled https for all the database downloads
 * Updated bowtie2 version to 2.5.3
+* Fix bypass-trim flag issue
 
 ## v0.12.3 06-24-2025
 * Fixed auto-close issue template

--- a/kneaddata/knead_data.py
+++ b/kneaddata/knead_data.py
@@ -74,7 +74,7 @@ except ImportError:
 from kneaddata import run
 from kneaddata import config
 
-VERSION="0.12.3"
+VERSION="0.12.4"
 
 # name global logging instance
 logger=logging.getLogger(__name__)

--- a/kneaddata/utilities.py
+++ b/kneaddata/utilities.py
@@ -377,8 +377,9 @@ def get_reformatted_identifiers(file, input_index, output_folder, temp_file_list
     print(message+"\n")
     logger.info(message)   
     
+    # make .fastq temp file
     file_out, new_file=tempfile.mkstemp(prefix="reformatted_identifiers",
-        suffix="_"+file_without_extension(file), dir=output_folder)
+        suffix="_"+os.path.basename(file), dir=output_folder)
     os.close(file_out)
     
     with open(new_file, "wt") as file_handle:

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ try:
 except ImportError:
     from urllib import urlretrieve
 
-VERSION="0.12.3"
+VERSION="0.12.4"
 AUTHOR = "KneadData Development Team"
 AUTHOR_EMAIL = "kneaddata-users@googlegroups.com"
 


### PR DESCRIPTION

The --bypass-trim flag was causing a crash because a specific temporary file did not need to be explicitly a .fastq file for trimming, but did for later steps in the pipeline. I've updated the reformatted identifier file to be a .fastq file to avoid this.  It is still flagged as a temporary file and removed.