### PR TITLE
Fix --run-trim-repetitive not finding fastqc dependency automatically

### DIFF
--- a/kneaddata/knead_data.py
+++ b/kneaddata/knead_data.py
@@ -391,7 +391,7 @@ def update_configuration(args):
             "--trf", bypass_permissions_check=False)
         
     # if fastqc is set to be run, check if the executable can be found
-    if args.fastqc_start or args.fastqc_end:
+    if args.fastqc_start or args.fastqc_end or args.run_trim_repetitive:
         args.fastqc_path=utilities.find_dependency(args.fastqc_path,config.fastqc_exe,"fastqc",
                                                    "--fastqc",bypass_permissions_check=False)
 


### PR DESCRIPTION
## Description
Small change to the code to add a check for the fastqc dependency not only when using --run-fastqc-start/end, but also when using --run-trim-repetitive, which also runs fastqc.

## Related Issue
The bug is so minor that I didn't create an issue for it. I noticed it, as I had a setup using both --run-fastqc-end and --run-trim-repetitive, which ran without issue, but when I removed the --run-fastqc-end option, it suddenly failed. I am sure it is fixed by setting --fastqc FASTQC, but I didn't actually try it, instead opting to fix the bug. 

## Screenshots (if appropriate):
N/A