### PR TITLE
fix: find fastqc dependency for trim-repetitive

### DIFF
--- a/kneaddata/knead_data.py
+++ b/kneaddata/knead_data.py
@@ -391,7 +391,7 @@ def update_configuration(args):
             "--trf", bypass_permissions_check=False)
         
     # if fastqc is set to be run, check if the executable can be found
-    if args.fastqc_start or args.fastqc_end:
+    if args.fastqc_start or args.fastqc_end or args.run_trim_repetitive:
         args.fastqc_path=utilities.find_dependency(args.fastqc_path,config.fastqc_exe,"fastqc",
                                                    "--fastqc",bypass_permissions_check=False)
 


### PR DESCRIPTION
FastQC is required for the trim-repetitive option, but might not be found if fastqc-start is not also run.  Simple fix is to always search for the dependency if trim-repetitive is specified.  